### PR TITLE
Fix: Ensure consistent list usage for argparse choices in CLI

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -236,7 +236,7 @@ def main():
     # predict command
     predict_help = "Predict lottery numbers.\nAvailable models:\n" + "\n".join([f"  - {name}" for name in AVAILABLE_MODELS.keys()])
     parser_predict = subparsers.add_parser('predict', help=predict_help, formatter_class=argparse.RawTextHelpFormatter)
-    parser_predict.add_argument('model_name', choices=AVAILABLE_MODELS.keys(), metavar='model_name', help='Name of the prediction model to use')
+    parser_predict.add_argument('model_name', choices=list(AVAILABLE_MODELS.keys()), metavar='model_name', help='Name of the prediction model to use')
 
     # predict-consensus command
     parser_consensus = subparsers.add_parser(


### PR DESCRIPTION
The 'predict-consensus' command was reportedly not being recognized correctly by argparse, with error messages indicating an incomplete list of available commands.

This was likely due to using a `dict_keys` object directly for the `choices` attribute of the 'model_name' argument in the 'predict' command. While often functional, using a concrete list is more robust for argparse.

This commit updates the 'predict' command's 'model_name' argument to use `choices=list(AVAILABLE_MODELS.keys())` instead of `choices=AVAILABLE_MODELS.keys()`. This ensures consistency with other parts of the CLI and follows argparse best practices, which should resolve the subparser registration issue and allow 'predict-consensus' to be recognized correctly.