### PR TITLE
Feat: Improve update-data output and clarity

### DIFF
--- a/fetch_real_data.py
+++ b/fetch_real_data.py
@@ -437,7 +437,7 @@ def update_euromillions_data():
 
     # Afficher un aperçu des données
     print("\nAperçu des données:")
-    print(df.head())
+    print(df.tail())
     
     # Ensure 'Date' column is in datetime format for min/max operations
     if 'Date' in df.columns and not pd.api.types.is_datetime64_any_dtype(df['Date']):
@@ -470,7 +470,7 @@ def update_euromillions_data():
     elif source == "CSV":
         status_message = f"Data updated using existing dataset 'euromillions_dataset.csv'. Total draws: {len(df_enhanced)}. Period: {date_min_str} to {date_max_str}."
     elif source == "synthetic":
-        status_message = f"Data updated using synthetic dataset. Total draws: {len(df_enhanced)}. Period: {date_min_str} to {date_max_str}."
+        status_message = f"Data updated using synthetic dataset. Total draws: {len(df_enhanced)}. Period: {date_min_str} to {date_max_str}. (Note: Synthetic data has a predefined end date, currently around 2025-06-06)."
     else:
         status_message = f"Data processed from unknown source. Total draws: {len(df_enhanced)}. Period: {date_min_str} to {date_max_str}."
 


### PR DESCRIPTION
This commit introduces two changes to `fetch_real_data.py` based on your feedback:

1.  The data preview within the `update-data` command's process now displays the last few entries (`df.tail()`) of the dataset instead of the first few (`df.head()`). This provides you with a more relevant snapshot of the most recent data.

2.  The status message generated when synthetic data is used now includes a note indicating that synthetic data has a predefined end date (currently around June 6th, 2025). This helps clarify why very recent or future dates might appear to be missing if the system falls back to using synthetically generated data.