### PR TITLE
Fix: Remove undefined TF model handlers from AVAILABLE_MODELS

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -272,9 +272,9 @@ def run_consensus_by_frequency_prediction(selected_model_names: list = None): # 
 AVAILABLE_MODELS = {
     'final_valide': run_final_valide,
     'revolutionnaire': run_revolutionnaire,
-    'agrege': run_agrege,
-    'tf_lstm_std': run_tf_lstm_std,
-    'tf_lstm_enhanced': run_tf_lstm_enhanced
+    'agrege': run_agrege
+    # 'tf_lstm_std': run_tf_lstm_std, # Removed
+    # 'tf_lstm_enhanced': run_tf_lstm_enhanced # Removed
     # Note: AVAILABLE_MODELS is now only used by the 'predict' command, not 'predict-consensus'.
     # The 'predict-consensus' --models arg now filters PREDICTOR_CONFIGS.
 }


### PR DESCRIPTION
I removed 'tf_lstm_std' and 'tf_lstm_enhanced' entries from the AVAILABLE_MODELS dictionary in `cli/main.py`.

These entries were causing a `NameError` at script parsing time because their corresponding handler functions (`run_tf_lstm_std`, `run_tf_lstm_enhanced`) were not defined within the scope of `cli/main.py`.

You can access TensorFlow model predictions via the `predict-consensus` command by configuring `predict_euromillions.py` (which uses the underlying TF models) in `PREDICTOR_CONFIGS`, or potentially by defining specific handlers for the `predict` command if you need them in the future.