### PR TITLE
Fix: Add missing import os in predicteur_final_valide.py

### DIFF
--- a/predicteur_final_valide.py
+++ b/predicteur_final_valide.py
@@ -17,6 +17,7 @@ import json
 from datetime import datetime, date as datetime_date # Renamed date to datetime_date
 import warnings
 import argparse # Added
+import os # Added
 # json is already imported
 from common.date_utils import get_next_euromillions_draw_date # Already Added
 from sklearn.linear_model import BayesianRidge


### PR DESCRIPTION
Added `import os` to `predicteur_final_valide.py` to resolve a NameError that occurred because `os.path.exists` was used without importing the `os` module.