### PR TITLE
Fix: Resolve IndentationError in load_comprehensive_learnings

### DIFF
--- a/aggregated_final_predictor.py
+++ b/aggregated_final_predictor.py
@@ -122,6 +122,7 @@ class AggregatedFinalPredictor:
                         result = json.load(f)
                     self.test_results.append(result)
                 except Exception as e:
+                    pass
                     # print(f"⚠️ Erreur lecture {file_path}: {e}", file=sys.stderr) # To stderr
         
         # print(f"✅ {len(self.test_results)} résultats de tests chargés") # Suppressed


### PR DESCRIPTION
The traceback `IndentationError: expected an indented block after 'except' statement on line 124` was traced to an `except Exception as e:` block within the `load_comprehensive_learnings` method in `aggregated_final_predictor.py`.

The issue was that this `except` block only contained a commented-out line, lacking an actual executable statement, which is required by the Python parser.

This commit adds a `pass` statement as the first line within this `except` block, satisfying the parser's requirement and resolving the IndentationError. The original commented-out print statement is preserved below the `pass`.