### PR TITLE
Fix: Extend subprocess timeout in cli/main.py to 5 minutes

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -208,7 +208,7 @@ def run_consensus_by_frequency_prediction(selected_model_names: list = None): # 
             command.extend(['--date', target_date_str])
 
         try:
-            process = subprocess.run(command, capture_output=True, text=True, timeout=60, check=False)
+            process = subprocess.run(command, capture_output=True, text=True, timeout=300, check=False)
 
             if process.returncode != 0:
                 error_message = f"Le script {script_name} a terminé avec le code {process.returncode}."
@@ -234,7 +234,7 @@ def run_consensus_by_frequency_prediction(selected_model_names: list = None): # 
                 failed_predictors.append({'name': script_name, 'reason': 'Sortie JSON invalide.'})
 
         except subprocess.TimeoutExpired:
-            print(f"Erreur: Le script {script_name} a dépassé le délai de 60 secondes.", file=sys.stderr)
+            print(f"Erreur: Le script {script_name} a dépassé le délai de 300 secondes.", file=sys.stderr)
             failed_predictors.append({'name': script_name, 'reason': 'Timeout'})
         except FileNotFoundError:
             print(f"Erreur: Script {script_path} non trouvé.", file=sys.stderr)


### PR DESCRIPTION
The `run_consensus_by_frequency_prediction` function in `cli/main.py` was timing out predictors after 60 seconds. This was causing issues for more computationally intensive predictors like `advanced_ml_predictor`.

This commit changes the `timeout` parameter in the `subprocess.run` call from 60 seconds to 300 seconds (5 minutes). The associated error message for `subprocess.TimeoutExpired` has also been updated to reflect the new timeout duration.