### PR TITLE
Fix: Correct output format for euromillions_predictor.py

### DIFF
--- a/euromillions_predictor.py
+++ b/euromillions_predictor.py
@@ -203,15 +203,27 @@ class EuromillionsPredictor:
         # Tri des numéros
         selected_main.sort()
         selected_stars.sort()
+
+        # Determine target_date_str for this prediction
+        current_target_date_str = None
+        if target_date_override_str:
+            current_target_date_str = target_date_override_str
+        elif actual_data_file_to_use: # Ensure we have a file to base the date on
+            next_draw_date_obj = get_next_euromillions_draw_date(actual_data_file_to_use)
+            if next_draw_date_obj:
+                current_target_date_str = next_draw_date_obj.strftime('%Y-%m-%d')
         
         # Création de la prédiction
         prediction = {
             "main_numbers": selected_main,
             "stars": selected_stars,
             "confidence": 0.5,
-            "method": "Analyse statistique",
-            "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            "method": "Analyse statistique", # Internal use, not for final JSON
+            "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S") # Internal use
         }
+
+        if current_target_date_str:
+            prediction["date_tirage_cible"] = current_target_date_str
         
         return prediction
     
@@ -395,10 +407,13 @@ class EuromillionsPredictor:
                     "nom_predicteur": "euromillions_predictor",
                     "numeros": prediction_data.get('main_numbers'),
                     "etoiles": prediction_data.get('stars'),
-                    "date_tirage_cible": prediction_data.get('date_tirage_cible'),
+                    # "date_tirage_cible": prediction_data.get('date_tirage_cible'), # Modified below
                     "confidence": prediction_data.get('confidence', 5.0), # Default confidence
                     "categorie": "Scientifique"
                 }
+                target_date_from_pred = prediction_data.get('date_tirage_cible')
+                if target_date_from_pred:
+                    output_dict["date_tirage_cible"] = target_date_from_pred
                 print(json.dumps(output_dict))
                 # self.display_prediction(prediction_data) # Suppressed for JSON output
                 # self.save_prediction(prediction_data) # Suppressed for JSON output


### PR DESCRIPTION
The euromillions_predictor.py script was producing an output that could lead to validation errors in cli/main.py, specifically concerning the `date_tirage_cible` field. If a target date was not determined by the predictor's main logic, the output JSON would include `"date_tirage_cible": null`, which failed type validation as a string was expected if the key was present.

This commit modifies euromillions_predictor.py in two ways:
1. The `generate_quick_prediction` method now attempts to determine the `date_tirage_cible` using `get_next_euromillions_draw_date` for its main prediction path (when data files are found) and only includes the key in its returned dictionary if a valid date string is found.
2. The `run` method, which constructs the final JSON output, now conditionally adds the `date_tirage_cible` key to the output dictionary. The key is only included if its value (obtained from `generate_quick_prediction`) is a non-empty string.

These changes ensure that the `date_tirage_cible` field is either a correctly formatted 'YYYY-MM-DD' string or the key is omitted entirely from the JSON output, both of which are acceptable to the validator in `cli/main.py`.