### PR TITLE
Fix: Ensure JSON serializable types in adaptive_singularity.py output

### DIFF
--- a/adaptive_singularity.py
+++ b/adaptive_singularity.py
@@ -632,12 +632,16 @@ def main():
     
     # print("\n🌟 SINGULARITÉ ADAPTÉE TERMINÉE AVEC SUCCÈS! 🌟") # Suppressed
 
+    raw_numeros = prediction_result.get('main_numbers', [])
+    raw_etoiles = prediction_result.get('stars', [])
+    raw_confidence = prediction_result.get('confidence_score', 7.5) # Default ensures it's a float
+
     output_dict = {
         "nom_predicteur": "adaptive_singularity",
-        "numeros": prediction_result.get('main_numbers'),
-        "etoiles": prediction_result.get('stars'),
+        "numeros": [int(n) for n in raw_numeros] if raw_numeros else [],
+        "etoiles": [int(s) for s in raw_etoiles] if raw_etoiles else [],
         "date_tirage_cible": target_date_str,
-        "confidence": prediction_result.get('confidence_score', 7.5), # Default from its typical range
+        "confidence": float(raw_confidence), # raw_confidence will be a number due to default
         "categorie": "Revolutionnaire"
     }
     print(json.dumps(output_dict))


### PR DESCRIPTION
The adaptive_singularity.py script was previously failing, with tracebacks indicating a TypeError during `json.dumps(output_dict)`. This was due to `output_dict` containing NumPy numerical types (e.g., np.int64, np.float64) for 'numeros', 'etoiles', or 'confidence', which are not directly serializable by the standard json library.

This commit modifies the `main()` function in adaptive_singularity.py to explicitly convert these NumPy types to their standard Python equivalents (int, float) before constructing `output_dict`. Specifically:
- Elements in the 'numeros' list are converted to `int`.
- Elements in the 'etoiles' list are converted to `int`.
- The 'confidence' value is converted to `float`.

This ensures that `json.dumps()` can successfully serialize the `output_dict`, resolving the TypeError and allowing the script to output its prediction correctly.